### PR TITLE
github.com/uber-go/multierr expects import "go.uber.org/multierr"

### DIFF
--- a/src/snowflakeamqp/fsm.go
+++ b/src/snowflakeamqp/fsm.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/streadway/amqp"
-	"github.com/uber-go/multierr"
+	"go.uber.org/multierr"
 )
 
 type state func() (state, error)


### PR DESCRIPTION
I still can't get it to work, but I'll bug you about that later.

For now this is the uber library name change so at least it runs.